### PR TITLE
Fixes issue #12: Directory.Exist return strange result

### DIFF
--- a/Pri.LongPath/Common.cs
+++ b/Pri.LongPath/Common.cs
@@ -74,7 +74,7 @@ namespace Pri.LongPath
 			{
 				System.IO.FileAttributes attributes;
 				int errorCode = TryGetFileAttributes(normalizedPath, out attributes);
-				if (errorCode == 0)
+				if (errorCode == 0 && (int)attributes != NativeMethods.INVALID_FILE_ATTRIBUTES)
 				{
 					isDirectory = Directory.IsDirectory(attributes);
 					return true;


### PR DESCRIPTION
In some strange situation the errorCode is still 0, even if the path doesn't exists.
In that case the attribute is -1, so we can check that the attribute is valid
