### PR TITLE
Fix for issue #45

### DIFF
--- a/Tests/UncDirectoryTests.cs
+++ b/Tests/UncDirectoryTests.cs
@@ -1153,6 +1153,15 @@ namespace Tests
             }
         }
 
+        [Test]
+        public void TestDirectoryCreateNearMaxPathLimit()
+        {
+            var uncPathNearMaxPathLimit = Path.Combine(uncDirectory, new string('x', Pri.LongPath.NativeMethods.MAX_PATH - uncDirectory.Length - 2));
+            Directory.CreateDirectory(uncPathNearMaxPathLimit);
+            Assert.That(Directory.Exists(uncPathNearMaxPathLimit));
+            Directory.Delete(uncPathNearMaxPathLimit);
+        }
+
         [TearDown]
         public void TearDown()
         {

--- a/Tests/UncDirectoryTests.cs
+++ b/Tests/UncDirectoryTests.cs
@@ -1162,6 +1162,27 @@ namespace Tests
             Directory.Delete(uncPathNearMaxPathLimit);
         }
 
+        [Test]
+        public void TestDirectoryEnumerateDirectoriesNearMaxPathLimit()
+        {
+            var uncPathNearMaxPathLimit = Path.Combine(uncDirectory, new string('x', Pri.LongPath.NativeMethods.MAX_PATH - uncDirectory.Length - 2));
+            Directory.CreateDirectory(uncPathNearMaxPathLimit.Replace(uncDirectory, directory));
+
+            var uncPathAboveMaxPathLimit = Path.Combine(uncPathNearMaxPathLimit, "wibble");
+            Directory.CreateDirectory(uncPathAboveMaxPathLimit);
+
+            Assert.That(Directory.Exists(uncPathNearMaxPathLimit));
+            Assert.That(Directory.Exists(uncPathAboveMaxPathLimit));
+
+            // there should be one subdirectory inside almostLongPath
+            var subDirs = Directory.EnumerateDirectories(uncPathNearMaxPathLimit).ToArray();
+
+            Directory.Delete(uncPathAboveMaxPathLimit);
+            Directory.Delete(uncPathNearMaxPathLimit);
+
+            Assert.That(subDirs.Length, Is.EqualTo(1));
+        }
+
         [TearDown]
         public void TearDown()
         {


### PR DESCRIPTION
I first added 2 unit tests that demonstrate issues when dealing with UNC paths near the `MAX_PATH` limit, one in `Directory.CreateDirectory` and one in `Directory.EnumerateDirectories`.

Empirically, I found that the point at which Windows starts getting upset is `MAX_PATH` _minus_ the length of the `\\hostname\` prefix of the UNC path.  I was therefore able to fix both issues by modifying the `Path.CheckAddLongPathPrefix` method such that it adds the long path prefix if the path exceeds this limit, rather than `MAX_PATH`.