### PR TITLE
Pass full path to error to avoid losing path info

### DIFF
--- a/Pri.LongPath/FileSystemInfo.cs
+++ b/Pri.LongPath/FileSystemInfo.cs
@@ -332,7 +332,7 @@ namespace Pri.LongPath
 			catch (Exception)
 			{
 				if (state != State.Error)
-					Common.ThrowIOError(Marshal.GetLastWin32Error(), string.Empty);
+					Common.ThrowIOError(Marshal.GetLastWin32Error(), FullPath);
 			}
 		}
 


### PR DESCRIPTION
Fixes #52

Pass the full path to `ThrowIOError` when an error occurs in `FileSystemInfo.Refresh()`, so that the error indicates the pass on which the error occurred.