### PR TITLE
README: remove notice about nuget

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,6 @@ Known Issues
 
 There are no known issues per se.  The only API that does not work as expected is `Directory.SetCurrentDirectory` as Windows does not support long paths for a current directory.
 
-A current *known issue* is no nuget package.  I hope to resolve that tout de suite!
-
 Caveats
 =======
 


### PR DESCRIPTION
I believe that NuGet package exists now, so it not an issue.