### PR TITLE
Fix issue #43 - race condition in directory creation

### DIFF
--- a/Pri.LongPath/Directory.cs
+++ b/Pri.LongPath/Directory.cs
@@ -702,11 +702,10 @@ namespace Pri.LongPath
 
 				// To mimic Directory.CreateDirectory, we don't throw if the directory (not a file) already exists
 				var errorCode = Marshal.GetLastWin32Error();
-				// PR: Not sure this is even possible, we check for existance above.
-				//if (errorCode != NativeMethods.ERROR_ALREADY_EXISTS || !Exists(path))
-				//{
-				throw Common.GetExceptionFromWin32Error(errorCode);
-				//}
+				if (errorCode != NativeMethods.ERROR_ALREADY_EXISTS || !Exists(path))
+				{
+					throw Common.GetExceptionFromWin32Error(errorCode);
+				}
 			}
 			return new DirectoryInfo(path);
 		}
@@ -789,11 +788,10 @@ namespace Pri.LongPath
 
 				// To mimic Directory.CreateDirectory, we don't throw if the directory (not a file) already exists
 				var errorCode = Marshal.GetLastWin32Error();
-				// PR: Not sure this is even possible, we check for existance above.
-				//if (errorCode != NativeMethods.ERROR_ALREADY_EXISTS || !Exists(path))
-				//{
-				throw Common.GetExceptionFromWin32Error(errorCode);
-				//}
+				if (errorCode != NativeMethods.ERROR_ALREADY_EXISTS || !Exists(path))
+				{
+					throw Common.GetExceptionFromWin32Error(errorCode);
+				}
 			}
 			return new DirectoryInfo(fullPath);
 		}


### PR DESCRIPTION
The "Not sure this is even possible" is wrong. Someone else can obviously come along in another thread and create the directory underneath you. If you're doing multi-threaded copy operations then this is actually quite likely; one of our apps is running into this all the time.