### PR TITLE
Mono support

### DIFF
--- a/Pri.LongPath/Common.cs
+++ b/Pri.LongPath/Common.cs
@@ -13,7 +13,12 @@ namespace Pri.LongPath
 
 	public class Common
 	{
-		private static readonly uint ProtectedDiscretionaryAcl = 0x80000000;
+	    public static bool IsRunningOnMono()
+	    {
+	       return Type.GetType("Mono.Runtime") != null;
+	    }
+
+	    private static readonly uint ProtectedDiscretionaryAcl = 0x80000000;
 		private static readonly uint ProtectedSystemAcl = 0x40000000;
 		private static readonly uint UnprotectedDiscretionaryAcl = 0x20000000;
 		private static readonly uint UnprotectedSystemAcl = 0x10000000;

--- a/Pri.LongPath/Directory.cs
+++ b/Pri.LongPath/Directory.cs
@@ -973,13 +973,13 @@ namespace Pri.LongPath
 
 		public static string[] GetDirectories(string path)
 		{
-		    if (Common.IsRunningOnMono()) System.IO.Directory.GetDirectories(path);
+		    if (Common.IsRunningOnMono()) return System.IO.Directory.GetDirectories(path);
 			return EnumerateFileSystemEntries(path, "*", true, false, SearchOption.TopDirectoryOnly).ToArray();
 		}
 
 		public static string[] GetDirectories(string path, string searchPattern)
 		{
-		    if (Common.IsRunningOnMono()) System.IO.Directory.GetDirectories(path, searchPattern);
+		    if (Common.IsRunningOnMono()) return System.IO.Directory.GetDirectories(path, searchPattern);
             return EnumerateFileSystemEntries(path, searchPattern, true, false, SearchOption.TopDirectoryOnly).ToArray();
 		}
 

--- a/Pri.LongPath/Directory.cs
+++ b/Pri.LongPath/Directory.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
 using System.Security.AccessControl;
 #if !NET_2_0
 using System.Linq;
@@ -47,7 +48,13 @@ namespace Pri.LongPath
 
 		public static void Delete(string path, bool recursive)
 		{
-			/* MSDN: https://msdn.microsoft.com/en-us/library/fxeahc5f.aspx
+		    if (Common.IsRunningOnMono())
+		    {
+		        System.IO.Directory.Delete(path, recursive);
+		        return;
+		    }
+
+            /* MSDN: https://msdn.microsoft.com/en-us/library/fxeahc5f.aspx
 			   The behavior of this method differs slightly when deleting a directory that contains a reparse point, 
 			   such as a symbolic link or a mount point. 
 			   (1) If the reparse point is a directory, such as a mount point, it is unmounted and the mount point is deleted. 
@@ -56,7 +63,7 @@ namespace Pri.LongPath
 			   the symbolic link.
 			*/
 
-			try 
+            try 
 			{
 				var reparseFlags = (System.IO.FileAttributes.Directory | System.IO.FileAttributes.ReparsePoint);
 				var isDirectoryReparsePoint = (Common.GetAttributes(path) & reparseFlags) == reparseFlags;
@@ -162,7 +169,12 @@ namespace Pri.LongPath
 		/// </exception>
 		public static void Delete(string path)
 		{
-			var normalizedPath = Path.NormalizeLongPath(path);
+		    if (Common.IsRunningOnMono())
+		    {
+		        System.IO.Directory.Delete(path);
+		    }
+
+		    var normalizedPath = Path.NormalizeLongPath(path);
 			if (!NativeMethods.RemoveDirectory(normalizedPath))
 			{
 				throw Common.GetExceptionFromLastWin32Error();
@@ -188,7 +200,9 @@ namespace Pri.LongPath
 		/// </remarks>
 		public static bool Exists(string path)
 		{
-			bool isDirectory;
+		    if (Common.IsRunningOnMono()) return System.IO.Directory.Exists(path);
+
+            bool isDirectory;
 			return Common.Exists(path, out isDirectory) && isDirectory;
 		}
 
@@ -237,7 +251,9 @@ namespace Pri.LongPath
 		/// </exception>
 		public static IEnumerable<string> EnumerateDirectories(string path)
 		{
-			return EnumerateFileSystemEntries(path, "*", true, false, SearchOption.TopDirectoryOnly);
+		    if (Common.IsRunningOnMono()) return System.IO.Directory.EnumerateDirectories(path);
+
+            return EnumerateFileSystemEntries(path, "*", true, false, SearchOption.TopDirectoryOnly);
 		}
 #endif
 
@@ -293,12 +309,17 @@ namespace Pri.LongPath
 		/// </exception>
 		public static IEnumerable<string> EnumerateDirectories(string path, string searchPattern)
 		{
-			return EnumerateFileSystemEntries(path, searchPattern, true, false, System.IO.SearchOption.TopDirectoryOnly);
+		    if (Common.IsRunningOnMono()) return System.IO.Directory.EnumerateDirectories(path, searchPattern);
+
+            return EnumerateFileSystemEntries(path, searchPattern, true, false, System.IO.SearchOption.TopDirectoryOnly);
 		}
 
 		public static IEnumerable<string> EnumerateDirectories(string path, string searchPattern, System.IO.SearchOption options)
 		{
-			return EnumerateFileSystemEntries(path, searchPattern, true, false, options);
+		    if (Common.IsRunningOnMono()) return System.IO.Directory.EnumerateDirectories(path, searchPattern, options);
+
+
+            return EnumerateFileSystemEntries(path, searchPattern, true, false, options);
 		}
 #endif
 
@@ -347,12 +368,16 @@ namespace Pri.LongPath
 		/// </exception>
 		public static IEnumerable<string> EnumerateFiles(string path)
 		{
-			return EnumerateFileSystemEntries(path, "*", false, true, SearchOption.TopDirectoryOnly);
+		    if (Common.IsRunningOnMono()) return System.IO.Directory.EnumerateFiles(path);
+
+            return EnumerateFileSystemEntries(path, "*", false, true, SearchOption.TopDirectoryOnly);
 		}
 
 		public static IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption options)
 		{
-			return EnumerateFileSystemEntries(path, searchPattern, false, true, options);
+		    if (Common.IsRunningOnMono()) return System.IO.Directory.EnumerateFiles(path, searchPattern, options);
+
+            return EnumerateFileSystemEntries(path, searchPattern, false, true, options);
 		}
 
 		/// <summary>
@@ -406,7 +431,9 @@ namespace Pri.LongPath
 		/// </exception>
 		public static IEnumerable<string> EnumerateFiles(string path, string searchPattern)
 		{
-			return EnumerateFileSystemEntries(path, searchPattern, false, true, SearchOption.TopDirectoryOnly);
+		    if (Common.IsRunningOnMono()) return System.IO.Directory.EnumerateFiles(path, searchPattern);
+
+            return EnumerateFileSystemEntries(path, searchPattern, false, true, SearchOption.TopDirectoryOnly);
 		}
 
 		/// <summary>
@@ -454,7 +481,9 @@ namespace Pri.LongPath
 		/// </exception>
 		public static IEnumerable<string> EnumerateFileSystemEntries(string path)
 		{
-			return EnumerateFileSystemEntries(path, null, true, true, SearchOption.TopDirectoryOnly);
+		    if (Common.IsRunningOnMono()) return System.IO.Directory.EnumerateFileSystemEntries(path);
+
+            return EnumerateFileSystemEntries(path, null, true, true, SearchOption.TopDirectoryOnly);
 		}
 
 		/// <summary>
@@ -508,18 +537,22 @@ namespace Pri.LongPath
 		/// </exception>
 		public static IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern)
 		{
-			return EnumerateFileSystemEntries(path, searchPattern, true, true, SearchOption.TopDirectoryOnly);
+		    if (Common.IsRunningOnMono()) return System.IO.Directory.EnumerateFileSystemEntries(path, searchPattern);
+
+            return EnumerateFileSystemEntries(path, searchPattern, true, true, SearchOption.TopDirectoryOnly);
 		}
 
 		public static IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern, SearchOption options)
 		{
-			return EnumerateFileSystemEntries(path, searchPattern, true, true, options);
+		    if (Common.IsRunningOnMono()) return System.IO.Directory.EnumerateFileSystemEntries(path, searchPattern, options);
+
+            return EnumerateFileSystemEntries(path, searchPattern, true, true, options);
 		}
 #endif // NET_4_0 || NET_4_5
 
 		internal static IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern, bool includeDirectories, bool includeFiles, SearchOption option)
 		{
-			var normalizedSearchPattern = Common.NormalizeSearchPattern(searchPattern);
+            var normalizedSearchPattern = Common.NormalizeSearchPattern(searchPattern);
 			var normalizedPath = Path.NormalizeLongPath(path);
 
 			return EnumerateNormalizedFileSystemEntries(includeDirectories, includeFiles, option, normalizedPath, normalizedSearchPattern);
@@ -660,6 +693,12 @@ namespace Pri.LongPath
 
 		public static void Move(string sourcePath, string destinationPath)
 		{
+		    if (Common.IsRunningOnMono())
+		    {
+                System.IO.File.Move(sourcePath, destinationPath);
+		        return;
+		    }
+
 			string normalizedSourcePath = Path.NormalizeLongPath(sourcePath, "sourcePath");
 			string normalizedDestinationPath = Path.NormalizeLongPath(destinationPath, "destinationPath");
 
@@ -755,6 +794,8 @@ namespace Pri.LongPath
 		/// </remarks>
 		public static DirectoryInfo CreateDirectory(string path)
 		{
+		    if (Common.IsRunningOnMono()) return new DirectoryInfo(System.IO.Directory.CreateDirectory(path).FullName);
+
 			if (Common.IsPathUnc(path)) return CreateDirectoryUnc(path);
 			var normalizedPath = Path.NormalizeLongPath(path);
 			var fullPath = Path.RemoveLongPathPrefix(normalizedPath);
@@ -798,17 +839,27 @@ namespace Pri.LongPath
 
 		public static string[] GetDirectories(string path, string searchPattern, SearchOption searchOption)
 		{
-			return EnumerateFileSystemEntries(path, searchPattern, true, false, searchOption).ToArray();
+		    if (Common.IsRunningOnMono()) return System.IO.Directory.GetDirectories(path, searchPattern, searchOption);
+
+            return EnumerateFileSystemEntries(path, searchPattern, true, false, searchOption).ToArray();
 		}
 
 		public static string[] GetFiles(string path)
 		{
-			return EnumerateFileSystemEntries(path, "*", false, true, SearchOption.TopDirectoryOnly).ToArray();
+		    if (Common.IsRunningOnMono()) return System.IO.Directory.GetFiles(path);
+
+            return EnumerateFileSystemEntries(path, "*", false, true, SearchOption.TopDirectoryOnly).ToArray();
 		}
 
 		public static unsafe void SetCreationTimeUtc(string path, DateTime creationTimeUtc)
 		{
-			var normalizedPath = Path.NormalizeLongPath(Path.GetFullPath(path));
+		    if (Common.IsRunningOnMono())
+		    {
+                System.IO.Directory.SetCreationTimeUtc(path, creationTimeUtc);
+		        return;
+		    }
+
+            var normalizedPath = Path.NormalizeLongPath(Path.GetFullPath(path));
 
 			using (var handle = GetDirectoryHandle(normalizedPath))
 			{
@@ -822,7 +873,12 @@ namespace Pri.LongPath
 
 		public static unsafe void SetLastWriteTimeUtc(string path, DateTime lastWriteTimeUtc)
 		{
-			var normalizedPath = Path.NormalizeLongPath(Path.GetFullPath(path));
+		    if (Common.IsRunningOnMono())
+		    {
+		        System.IO.Directory.SetLastWriteTimeUtc(path, lastWriteTimeUtc);
+		        return;
+		    }
+            var normalizedPath = Path.NormalizeLongPath(Path.GetFullPath(path));
 
 			using (SafeFileHandle handle = GetDirectoryHandle(normalizedPath))
 			{
@@ -836,7 +892,13 @@ namespace Pri.LongPath
 
 		public static unsafe void SetLastAccessTimeUtc(string path, DateTime lastWriteTimeUtc)
 		{
-			var normalizedPath = Path.NormalizeLongPath(Path.GetFullPath(path));
+		    if (Common.IsRunningOnMono())
+		    {
+		        System.IO.Directory.SetLastAccessTimeUtc(path, lastWriteTimeUtc);
+		        return;
+		    }
+
+            var normalizedPath = Path.NormalizeLongPath(Path.GetFullPath(path));
 
 			using (var handle = GetDirectoryHandle(normalizedPath))
 			{
@@ -869,6 +931,8 @@ namespace Pri.LongPath
 
 		public static DirectorySecurity GetAccessControl(string path, AccessControlSections includeSections)
 		{
+		    if (Common.IsRunningOnMono()) return System.IO.Directory.GetAccessControl(path, includeSections);
+
 			var normalizedPath = Path.NormalizeLongPath(Path.GetFullPath(path));
 			IntPtr sidOwner, sidGroup, dacl, sacl, byteArray;
 			var securityInfos = Common.ToSecurityInfos(includeSections);
@@ -909,12 +973,14 @@ namespace Pri.LongPath
 
 		public static string[] GetDirectories(string path)
 		{
+		    if (Common.IsRunningOnMono()) System.IO.Directory.GetDirectories(path);
 			return EnumerateFileSystemEntries(path, "*", true, false, SearchOption.TopDirectoryOnly).ToArray();
 		}
 
 		public static string[] GetDirectories(string path, string searchPattern)
 		{
-			return EnumerateFileSystemEntries(path, searchPattern, true, false, SearchOption.TopDirectoryOnly).ToArray();
+		    if (Common.IsRunningOnMono()) System.IO.Directory.GetDirectories(path, searchPattern);
+            return EnumerateFileSystemEntries(path, searchPattern, true, false, SearchOption.TopDirectoryOnly).ToArray();
 		}
 
 		public static string GetDirectoryRoot(string path)
@@ -925,27 +991,32 @@ namespace Pri.LongPath
 
 		public static string[] GetFiles(string path, string searchPattern)
 		{
+		    if (Common.IsRunningOnMono()) return System.IO.Directory.GetFiles(path, searchPattern);
 			return EnumerateFileSystemEntries(path, searchPattern, false, true, SearchOption.TopDirectoryOnly).ToArray();
 		}
 
 		public static string[] GetFiles(string path, string searchPattern, SearchOption options)
 		{
-			return EnumerateFileSystemEntries(path, searchPattern, false, true, options).ToArray();
+		    if (Common.IsRunningOnMono()) return System.IO.Directory.GetFiles(path, searchPattern, options);
+            return EnumerateFileSystemEntries(path, searchPattern, false, true, options).ToArray();
 		}
 
 		public static string[] GetFileSystemEntries(string path)
 		{
-			return EnumerateFileSystemEntries(path, null, true, true, SearchOption.TopDirectoryOnly).ToArray();
+		    if (Common.IsRunningOnMono()) return System.IO.Directory.GetFileSystemEntries(path);
+            return EnumerateFileSystemEntries(path, null, true, true, SearchOption.TopDirectoryOnly).ToArray();
 		}
 
 		public static string[] GetFileSystemEntries(string path, string searchPattern)
 		{
-			return EnumerateFileSystemEntries(path, searchPattern, true, true, SearchOption.TopDirectoryOnly).ToArray();
+		    if (Common.IsRunningOnMono()) return System.IO.Directory.GetFileSystemEntries(path, searchPattern);
+            return EnumerateFileSystemEntries(path, searchPattern, true, true, SearchOption.TopDirectoryOnly).ToArray();
 		}
 
 		public static string[] GetFileSystemEntries(string path, string searchPattern, SearchOption options)
 		{
-			return EnumerateFileSystemEntries(path, searchPattern, true, true, options).ToArray();
+		    if (Common.IsRunningOnMono()) return System.IO.Directory.GetFileSystemEntries(path, searchPattern);
+            return EnumerateFileSystemEntries(path, searchPattern, true, true, options).ToArray();
 		}
 
 		public static DateTime GetLastAccessTime(string path)
@@ -955,7 +1026,9 @@ namespace Pri.LongPath
 
 		public static DateTime GetLastAccessTimeUtc(string path)
 		{
-			var di = new DirectoryInfo(path);
+		    if (Common.IsRunningOnMono()) return System.IO.Directory.GetLastAccessTimeUtc(path);
+
+            var di = new DirectoryInfo(path);
 			return di.LastAccessTimeUtc;
 		}
 
@@ -966,7 +1039,9 @@ namespace Pri.LongPath
 
 		public static DateTime GetLastWriteTimeUtc(string path)
 		{
-			var di = new DirectoryInfo(path);
+		    if (Common.IsRunningOnMono()) return System.IO.Directory.GetLastWriteTimeUtc(path);
+
+            var di = new DirectoryInfo(path);
 			return di.LastWriteTimeUtc;
 		}
 
@@ -977,7 +1052,13 @@ namespace Pri.LongPath
 
 		public static void SetAccessControl(string path, DirectorySecurity directorySecurity)
 		{
-			if (path == null) throw new ArgumentNullException("path");
+		    if (Common.IsRunningOnMono())
+		    {
+		        System.IO.Directory.SetAccessControl(path, directorySecurity);
+		        return;
+		    }
+
+            if (path == null) throw new ArgumentNullException("path");
 			if (directorySecurity == null) throw new ArgumentNullException("directorySecurity");
 			var name = Path.NormalizeLongPath(Path.GetFullPath(path));
 
@@ -996,7 +1077,13 @@ namespace Pri.LongPath
 
 		public static void SetLastWriteTime(string path, DateTime lastWriteTimeUtc)
 		{
-			unsafe
+		    if (Common.IsRunningOnMono())
+		    {
+		        System.IO.Directory.SetLastWriteTime(path, lastWriteTimeUtc);
+		        return;
+		    }
+
+            unsafe
 			{
 				var normalizedPath = Path.NormalizeLongPath(Path.GetFullPath(path));
 
@@ -1013,8 +1100,13 @@ namespace Pri.LongPath
 
 		public static void SetCurrentDirectory(string path)
 		{
+		    if (Common.IsRunningOnMono())
+		    {
+		        System.IO.Directory.SetCurrentDirectory(path);
+		        return;
+		    }
 #if true
-			throw new NotSupportedException("Windows does not support setting the current directory to a long path");
+            throw new NotSupportedException("Windows does not support setting the current directory to a long path");
 #else
 			string normalizedPath = Path.NormalizeLongPath(Path.GetFullPath(path));
 			if (!NativeMethods.SetCurrentDirectory(normalizedPath))

--- a/Pri.LongPath/DirectoryInfo.cs
+++ b/Pri.LongPath/DirectoryInfo.cs
@@ -16,6 +16,16 @@ namespace Pri.LongPath
 	{
 		private readonly string _name;
 
+	    public override System.IO.FileSystemInfo SystemInfo { get { return SysDirectoryInfo; } }
+
+        private System.IO.DirectoryInfo SysDirectoryInfo
+	    {
+	        get
+	        {
+	            return new System.IO.DirectoryInfo(FullPath);
+	        }
+	    }
+
 		public override bool Exists
 		{
 			get
@@ -96,13 +106,17 @@ namespace Pri.LongPath
 #if NET_4_0 || NET_4_5
 		public IEnumerable<DirectoryInfo> EnumerateDirectories(string searchPattern)
 		{
-			return Directory.EnumerateFileSystemEntries(FullPath, searchPattern, true, false, System.IO.SearchOption.TopDirectoryOnly)
+		    if (Common.IsRunningOnMono()) return SysDirectoryInfo.EnumerateDirectories(searchPattern).Select(s => new DirectoryInfo(s.FullName));
+
+            return Directory.EnumerateFileSystemEntries(FullPath, searchPattern, true, false, System.IO.SearchOption.TopDirectoryOnly)
 				.Select(directory => new DirectoryInfo(directory));
 		}
 
 		public IEnumerable<DirectoryInfo> EnumerateDirectories(string searchPattern, SearchOption searchOption)
 		{
-			return Directory.EnumerateFileSystemEntries(FullPath, searchPattern, true, false, searchOption)
+		    if (Common.IsRunningOnMono()) return SysDirectoryInfo.EnumerateDirectories(searchPattern, searchOption).Select(s => new DirectoryInfo(s.FullName));
+
+            return Directory.EnumerateFileSystemEntries(FullPath, searchPattern, true, false, searchOption)
 				.Select(directory => new DirectoryInfo(directory));
 		}
 
@@ -113,24 +127,31 @@ namespace Pri.LongPath
 
 		public IEnumerable<FileInfo> EnumerateFiles(string searchPattern)
 		{
-			return Directory.EnumerateFileSystemEntries(FullPath, searchPattern, false, true, System.IO.SearchOption.TopDirectoryOnly).Select(e => new FileInfo(e));
+		    if (Common.IsRunningOnMono()) return SysDirectoryInfo.EnumerateFiles(searchPattern).Select(s => new FileInfo(s.FullName));
+
+            return Directory.EnumerateFileSystemEntries(FullPath, searchPattern, false, true, System.IO.SearchOption.TopDirectoryOnly).Select(e => new FileInfo(e));
 		}
 
 		public IEnumerable<FileInfo> EnumerateFiles(string searchPattern, SearchOption searchOption)
 		{
-			return Directory.EnumerateFileSystemEntries(FullPath, searchPattern, false, true, searchOption).Select(e => new FileInfo(e));
+		    if (Common.IsRunningOnMono()) return SysDirectoryInfo.EnumerateFiles(searchPattern, searchOption).Select(s => new FileInfo(s.FullName));
+
+            return Directory.EnumerateFileSystemEntries(FullPath, searchPattern, false, true, searchOption).Select(e => new FileInfo(e));
 		}
 
 		public IEnumerable<FileSystemInfo> EnumerateFileSystemInfos()
 		{
-			return
+            return
 				Directory.EnumerateFileSystemEntries(FullPath)
 					.Select(e => Directory.Exists(e) ? (FileSystemInfo)new DirectoryInfo(e) : (FileSystemInfo)new FileInfo(e));
 		}
 
 		public IEnumerable<FileSystemInfo> EnumerateFileSystemInfos(string searchPattern)
 		{
-			return Directory.EnumerateFileSystemEntries(FullPath, searchPattern, true, true, System.IO.SearchOption.TopDirectoryOnly)
+		    if (Common.IsRunningOnMono()) return SysDirectoryInfo.EnumerateFileSystemInfos(searchPattern)
+                    .Select(e => System.IO.Directory.Exists(e.FullName) ? (FileSystemInfo)new DirectoryInfo(e.FullName) : (FileSystemInfo)new FileInfo(e.FullName));
+
+            return Directory.EnumerateFileSystemEntries(FullPath, searchPattern, true, true, System.IO.SearchOption.TopDirectoryOnly)
 					.Select(e => Directory.Exists(e) ? (FileSystemInfo)new DirectoryInfo(e) : (FileSystemInfo)new FileInfo(e));
 		}
 #if NET_4_5
@@ -155,6 +176,12 @@ namespace Pri.LongPath
 
 		public void MoveTo(string destDirName)
 		{
+		    if (Common.IsRunningOnMono())
+		    {
+                SysDirectoryInfo.MoveTo(destDirName);
+		        return;
+		    }
+
 			if (destDirName == null) throw new ArgumentNullException("destDirName");
 #if NET_2_0
 			if (string.IsNullOrEmpty(destDirName))
@@ -203,7 +230,12 @@ namespace Pri.LongPath
 
 		public IEnumerable<DirectoryInfo> EnumerateDirectories()
 		{
-			return Directory.EnumerateFileSystemEntries(FullPath, "*", true, false, System.IO.SearchOption.TopDirectoryOnly).Select(directory => new DirectoryInfo(directory));
+		    if (Common.IsRunningOnMono())
+            {
+                return SysDirectoryInfo.EnumerateDirectories().Select(s => new DirectoryInfo(s.FullName));
+            }
+
+            return Directory.EnumerateFileSystemEntries(FullPath, "*", true, false, System.IO.SearchOption.TopDirectoryOnly).Select(directory => new DirectoryInfo(directory));
 		}
 
 		public DirectorySecurity GetAccessControl()
@@ -243,23 +275,30 @@ namespace Pri.LongPath
 
 		public FileInfo[] GetFiles()
 		{
+		    if (Common.IsRunningOnMono()) return SysDirectoryInfo.GetFiles().Select(s => new FileInfo(s.FullName)).ToArray();
 			return Directory.EnumerateFileSystemEntries(FullPath, "*", false, true, System.IO.SearchOption.TopDirectoryOnly).Select(path => new FileInfo(path)).ToArray();
 		}
 
 		public FileSystemInfo[] GetFileSystemInfos(string searchPattern)
 		{
-			return Directory.EnumerateFileSystemEntries(FullPath, searchPattern, true, true, System.IO.SearchOption.TopDirectoryOnly)
+		    if (Common.IsRunningOnMono()) return SysDirectoryInfo.GetFileSystemInfos(searchPattern).Select(s => s.FullName).Select(e => Directory.Exists(e) ? (FileSystemInfo)new DirectoryInfo(e) : (FileSystemInfo)new FileInfo(e)).ToArray();
+     
+            return Directory.EnumerateFileSystemEntries(FullPath, searchPattern, true, true, System.IO.SearchOption.TopDirectoryOnly)
 					.Select(e => Directory.Exists(e) ? (FileSystemInfo)new DirectoryInfo(e) : (FileSystemInfo)new FileInfo(e)).ToArray();
 		}
 
 		public FileSystemInfo[] GetFileSystemInfos(string searchPattern, SearchOption searchOption)
 		{
-			return Directory.EnumerateFileSystemEntries(FullPath, searchPattern, true, true, searchOption)
+		    if (Common.IsRunningOnMono()) return SysDirectoryInfo.GetFileSystemInfos(searchPattern, searchOption).Select(s => s.FullName).Select(e => Directory.Exists(e) ? (FileSystemInfo)new DirectoryInfo(e) : (FileSystemInfo)new FileInfo(e)).ToArray();
+
+            return Directory.EnumerateFileSystemEntries(FullPath, searchPattern, true, true, searchOption)
 					.Select(e => Directory.Exists(e) ? (FileSystemInfo)new DirectoryInfo(e) : (FileSystemInfo)new FileInfo(e)).ToArray();
 		}
 
 		public FileSystemInfo[] GetFileSystemInfos()
 		{
+		    if (Common.IsRunningOnMono()) return SysDirectoryInfo.GetFileSystemInfos().Select(s => s.FullName).Select(e => Directory.Exists(e) ? (FileSystemInfo)new DirectoryInfo(e) : (FileSystemInfo)new FileInfo(e)).ToArray();
+
 			return Directory.EnumerateFileSystemEntries(FullPath, "*", true, true, System.IO.SearchOption.TopDirectoryOnly)
 					.Select(e => Directory.Exists(e) ? (FileSystemInfo)new DirectoryInfo(e) : (FileSystemInfo)new FileInfo(e)).ToArray();
 		}

--- a/Pri.LongPath/File.cs
+++ b/Pri.LongPath/File.cs
@@ -25,24 +25,31 @@ namespace Pri.LongPath
 	using FileStream = System.IO.FileStream;
 	using StreamWriter = System.IO.StreamWriter;
 	using StreamReader = System.IO.StreamReader;
+    using SysFile = System.IO.File;
 
 	public static class File
 	{
 		public static StreamReader OpenText(string path)
 		{
+		    if (Common.IsRunningOnMono()) return SysFile.OpenText(path);
+
 			var stream = Open(path, FileMode.Open, FileAccess.Read, FileShare.Read, DefaultBufferSize, FileOptions.SequentialScan);
 			return new StreamReader(stream, Encoding.UTF8, true, 1024);
 		}
 
 		private static StreamReader OpenText(string path, Encoding encoding)
 		{
-			var stream = Open(path, FileMode.Open, FileAccess.Read, FileShare.Read, DefaultBufferSize, FileOptions.SequentialScan);
+		    if (Common.IsRunningOnMono()) return SysFile.OpenText(path);
+
+            var stream = Open(path, FileMode.Open, FileAccess.Read, FileShare.Read, DefaultBufferSize, FileOptions.SequentialScan);
 			return new StreamReader(stream, encoding, true, 1024);
 		}
 
 		public static StreamWriter CreateText(String path)
 		{
-			var fileStream = Open(path, FileMode.Create, FileAccess.Write, FileShare.Read, DefaultBufferSize, FileOptions.SequentialScan);
+		    if (Common.IsRunningOnMono()) return SysFile.CreateText(path);
+
+            var fileStream = Open(path, FileMode.Create, FileAccess.Write, FileShare.Read, DefaultBufferSize, FileOptions.SequentialScan);
 			return new StreamWriter(fileStream, UTF8NoBOM, DefaultBufferSize);
 		}
 
@@ -129,6 +136,8 @@ namespace Pri.LongPath
 		/// </exception>
 		public static void Copy(string sourcePath, string destinationPath, bool overwrite)
 		{
+            if (Common.IsRunningOnMono()) SysFile.Copy(sourcePath, destinationPath, overwrite);
+
 			string normalizedSourcePath = Path.NormalizeLongPath(sourcePath, "sourcePath");
 			string normalizedDestinationPath = Path.NormalizeLongPath(destinationPath, "destinationPath");
 
@@ -143,12 +152,14 @@ namespace Pri.LongPath
 
 		public static FileStream Create(string path, int bufferSize)
 		{
+		    if (Common.IsRunningOnMono()) return SysFile.Create(path, bufferSize);
 			return Open(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None, bufferSize, FileOptions.None);
 		}
 
 		public static FileStream Create(string path, int bufferSize, FileOptions options)
 		{
-			return Open(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None, bufferSize, options);
+		    if (Common.IsRunningOnMono()) return SysFile.Create(path, bufferSize, options);
+            return Open(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None, bufferSize, options);
 		}
 
 		public static FileStream Create(string path, int bufferSize, FileOptions options, FileSecurity fileSecurity)
@@ -209,7 +220,13 @@ namespace Pri.LongPath
 		/// </exception>
 		public static void Delete(string path)
 		{
-			string normalizedPath = Path.NormalizeLongPath(path);
+		    if (Common.IsRunningOnMono())
+		    {
+		        SysFile.Delete(path);
+		        return;
+		    }
+
+            string normalizedPath = Path.NormalizeLongPath(path);
 			if (!NativeMethods.DeleteFile(normalizedPath))
 			{
 				throw Common.GetExceptionFromLastWin32Error();
@@ -218,7 +235,13 @@ namespace Pri.LongPath
 
 		public static void Decrypt(string path)
 		{
-			String fullPath = Path.GetFullPath(path);
+		    if (Common.IsRunningOnMono())
+		    {
+		        SysFile.Decrypt(path);
+		        return;
+		    }
+
+            String fullPath = Path.GetFullPath(path);
 			string normalizedPath = Path.NormalizeLongPath(fullPath);
 			if (NativeMethods.DecryptFile(normalizedPath, 0)) return;
 			int errorCode = Marshal.GetLastWin32Error();
@@ -233,7 +256,12 @@ namespace Pri.LongPath
 
 		public static void Encrypt(String path)
 		{
-			String fullPath = Path.GetFullPath(path);
+		    if (Common.IsRunningOnMono())
+		    {
+		        SysFile.Encrypt(path);
+		        return;
+		    }
+            String fullPath = Path.GetFullPath(path);
 			string normalizedPath = Path.NormalizeLongPath(fullPath);
 			if (NativeMethods.EncryptFile(normalizedPath)) return;
 			int errorCode = Marshal.GetLastWin32Error();
@@ -265,7 +293,10 @@ namespace Pri.LongPath
 		/// </remarks>
 		public static bool Exists(string path)
 		{
-			bool isDirectory;
+		    if (Common.IsRunningOnMono())
+		        return SysFile.Exists(path);
+
+            bool isDirectory;
 			if (Common.Exists(path, out isDirectory))
 			{
 				return !isDirectory;
@@ -276,7 +307,10 @@ namespace Pri.LongPath
 
 		public static FileStream Open(string path, FileMode mode)
 		{
-			return File.Open(path, mode, (mode == FileMode.Append ? FileAccess.Write : FileAccess.ReadWrite), FileShare.None);
+		    if (Common.IsRunningOnMono())
+		        return SysFile.Open(path, mode);
+
+            return File.Open(path, mode, (mode == FileMode.Append ? FileAccess.Write : FileAccess.ReadWrite), FileShare.None);
 		}
 
 		/// <summary>
@@ -341,7 +375,10 @@ namespace Pri.LongPath
 		/// </exception>
 		public static FileStream Open(string path, FileMode mode, FileAccess access)
 		{
-			return Open(path, mode, access, FileShare.None, 0, FileOptions.None);
+		    if (Common.IsRunningOnMono())
+		        return SysFile.Open(path, mode, access);
+
+            return Open(path, mode, access, FileShare.None, 0, FileOptions.None);
 		}
 
 		/// <summary>
@@ -410,7 +447,10 @@ namespace Pri.LongPath
 		/// </exception>
 		public static FileStream Open(string path, FileMode mode, FileAccess access, FileShare share)
 		{
-			return Open(path, mode, access, share, 0, FileOptions.None);
+		    if (Common.IsRunningOnMono())
+		        return SysFile.Open(path, mode, access, share);
+
+            return Open(path, mode, access, share, 0, FileOptions.None);
 		}
 
 		/// <summary>
@@ -505,12 +545,18 @@ namespace Pri.LongPath
 
 		public static void SetCreationTime(String path, DateTime creationTime)
 		{
-			SetCreationTimeUtc(path, creationTime.ToUniversalTime());
+            SetCreationTimeUtc(path, creationTime.ToUniversalTime());
 		}
 
 		public static unsafe void SetCreationTimeUtc(String path, DateTime creationTimeUtc)
 		{
-			string normalizedPath = Path.NormalizeLongPath(path);
+		    if (Common.IsRunningOnMono())
+		    {
+		        SysFile.SetCreationTimeUtc(path, creationTimeUtc);
+		        return;
+		    }
+
+            string normalizedPath = Path.NormalizeLongPath(path);
 			using (SafeFileHandle handle = GetFileHandle(normalizedPath,
 				FileMode.Open, FileAccess.Write, FileShare.ReadWrite, FileOptions.None))
 			{
@@ -542,7 +588,13 @@ namespace Pri.LongPath
 
 		public static unsafe void SetLastWriteTimeUtc(String path, DateTime lastWriteTimeUtc)
 		{
-			string normalizedPath = Path.NormalizeLongPath(path);
+		    if (Common.IsRunningOnMono())
+		    {
+		        SysFile.SetLastWriteTimeUtc(path, lastWriteTimeUtc);
+		        return;
+		    }
+
+            string normalizedPath = Path.NormalizeLongPath(path);
 			using (SafeFileHandle handle = GetFileHandle(normalizedPath,
 				FileMode.Open, FileAccess.Write, FileShare.ReadWrite, FileOptions.None))
 			{
@@ -574,7 +626,12 @@ namespace Pri.LongPath
 
 		public static unsafe void SetLastAccessTimeUtc(String path, DateTime lastAccessTimeUtc)
 		{
-			string normalizedPath = Path.NormalizeLongPath(path);
+		    if (Common.IsRunningOnMono())
+		    {
+		        SysFile.SetLastAccessTimeUtc(path, lastAccessTimeUtc);
+		        return;
+		    }
+            string normalizedPath = Path.NormalizeLongPath(path);
 			using (SafeFileHandle handle = GetFileHandle(normalizedPath,
 				FileMode.Open, FileAccess.Write, FileShare.ReadWrite, FileOptions.None))
 			{
@@ -601,22 +658,27 @@ namespace Pri.LongPath
 
 		public static FileAttributes GetAttributes(string path)
 		{
+		    if (Common.IsRunningOnMono()) return SysFile.GetAttributes(path);
 			return Common.GetFileAttributes(path);
 		}
 
 		public static void SetAttributes(string path, FileAttributes fileAttributes)
 		{
+            if (Common.IsRunningOnMono()) SysFile.SetAttributes(path, fileAttributes);
 			Common.SetAttributes(path, fileAttributes);
 		}
 
 		public static FileStream OpenRead(String path)
 		{
-			return Open(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+		    if (Common.IsRunningOnMono()) SysFile.OpenRead(path);
+            return Open(path, FileMode.Open, FileAccess.Read, FileShare.Read);
 		}
 
 		public static FileStream OpenWrite(String path)
 		{
-			return Open(path, FileMode.OpenOrCreate, FileAccess.Write, FileShare.None);
+		    if (Common.IsRunningOnMono()) SysFile.OpenWrite(path);
+
+            return Open(path, FileMode.OpenOrCreate, FileAccess.Write, FileShare.None);
 		}
 
 		public static string ReadAllText(string path)
@@ -826,7 +888,13 @@ namespace Pri.LongPath
 		/// </exception>
 		public static void Move(string sourcePath, string destinationPath)
 		{
-			string normalizedSourcePath = Path.NormalizeLongPath(sourcePath, "sourcePath");
+		    if (Common.IsRunningOnMono())
+		    {
+		        SysFile.Move(sourcePath, destinationPath);
+                return;
+		    }
+
+            string normalizedSourcePath = Path.NormalizeLongPath(sourcePath, "sourcePath");
 			string normalizedDestinationPath = Path.NormalizeLongPath(destinationPath, "destinationPath");
 
 			if (!NativeMethods.MoveFile(normalizedSourcePath, normalizedDestinationPath))
@@ -844,7 +912,13 @@ namespace Pri.LongPath
 		public static void Replace(String sourceFileName, String destinationFileName, String destinationBackupFileName,
 			bool ignoreMetadataErrors)
 		{
-			if (sourceFileName == null) throw new ArgumentNullException("sourceFileName");
+		    if (Common.IsRunningOnMono())
+		    {
+		        SysFile.Replace(sourceFileName, destinationFileName, destinationBackupFileName, ignoreMetadataErrors);
+                return;
+		    }
+
+            if (sourceFileName == null) throw new ArgumentNullException("sourceFileName");
 			if (destinationFileName == null) throw new ArgumentNullException("destinationFileName");
 
 			String fullSrcPath = Path.NormalizeLongPath(Path.GetFullPath(sourceFileName));
@@ -865,7 +939,13 @@ namespace Pri.LongPath
 
 		public static void SetAccessControl(string path, FileSecurity fileSecurity)
 		{
-			if (path == null) throw new ArgumentNullException("path");
+		    if (Common.IsRunningOnMono())
+		    {
+		        SysFile.SetAccessControl(path, fileSecurity);
+		        return;
+		    }
+
+            if (path == null) throw new ArgumentNullException("path");
 			if (fileSecurity == null) throw new ArgumentNullException("fileSecurity");
 			var name = Path.NormalizeLongPath(Path.GetFullPath(path));
 
@@ -880,7 +960,10 @@ namespace Pri.LongPath
 
 		public static FileSecurity GetAccessControl(string path, AccessControlSections includeSections)
 		{
-			var normalizedPath = Path.NormalizeLongPath(Path.GetFullPath(path));
+		    if (Common.IsRunningOnMono()) return SysFile.GetAccessControl(path, includeSections);
+
+
+            var normalizedPath = Path.NormalizeLongPath(Path.GetFullPath(path));
 
 			IntPtr SidOwner, SidGroup, Dacl, Sacl, ByteArray;
 			SecurityInfos SecurityInfos =
@@ -911,8 +994,8 @@ namespace Pri.LongPath
 
 		[SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "handle is stored by caller")]
 		internal static SafeFileHandle GetFileHandle(string normalizedPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)
-		{
-			bool append = mode == FileMode.Append;
+        { 
+            bool append = mode == FileMode.Append;
 			if (append)
 			{
 				mode = FileMode.OpenOrCreate;

--- a/Pri.LongPath/FileInfo.cs
+++ b/Pri.LongPath/FileInfo.cs
@@ -25,7 +25,17 @@ namespace Pri.LongPath
 			}
 		}
 
-		public string DirectoryName
+	    public System.IO.FileInfo SysFileInfo
+        {
+	        get
+	        {
+	            return new System.IO.FileInfo(FullPath);
+	        }
+        }
+
+	    public override System.IO.FileSystemInfo SystemInfo { get { return SysFileInfo; } }
+
+        public string DirectoryName
 		{
 			get
 			{
@@ -37,6 +47,8 @@ namespace Pri.LongPath
 		{
 			get
 			{
+			    if (Common.IsRunningOnMono()) return SysFileInfo.Exists;
+
 				if (state == State.Uninitialized)
 				{
 					Refresh();
@@ -71,7 +83,9 @@ namespace Pri.LongPath
 
 		private long GetFileLength()
 		{
-			if (state == State.Uninitialized)
+		    if (Common.IsRunningOnMono()) return SysFileInfo.Length;
+
+            if (state == State.Uninitialized)
 			{
 				Refresh();
 			}
@@ -128,12 +142,15 @@ namespace Pri.LongPath
 
 		public FileStream Open(FileMode mode, FileAccess access, FileShare share)
 		{
-			return File.Open(FullPath, mode, access, share, 4096, FileOptions.SequentialScan);
+		    if (Common.IsRunningOnMono()) return SysFileInfo.Open(mode, access, share);
+
+            return File.Open(FullPath, mode, access, share, 4096, FileOptions.SequentialScan);
 		}
 
 		public FileStream OpenRead()
 		{
-			return File.Open(FullPath, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, FileOptions.None);
+		    if (Common.IsRunningOnMono()) return SysFileInfo.OpenRead();
+            return File.Open(FullPath, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, FileOptions.None);
 		}
 
 		public StreamReader OpenText()
@@ -165,11 +182,19 @@ namespace Pri.LongPath
 		{
 			get
 			{
-				return (Attributes & FileAttributes.ReadOnly) != 0;
+			    if (Common.IsRunningOnMono()) return SysFileInfo.IsReadOnly;
+
+                return (Attributes & FileAttributes.ReadOnly) != 0;
 			}
 			set
 			{
-				if (value)
+			    if (Common.IsRunningOnMono())
+			    {
+			        SysFileInfo.IsReadOnly = value;
+			        return;
+			    }
+
+                if (value)
 				{
 					Attributes |= FileAttributes.ReadOnly;
 					return;

--- a/Pri.LongPath/FileSystemInfo.cs
+++ b/Pri.LongPath/FileSystemInfo.cs
@@ -17,37 +17,44 @@ namespace Pri.LongPath
 		protected readonly FileAttributeData data = new FileAttributeData();
 		protected int errorCode;
 
-		// Summary:
-		//     Gets or sets the attributes for the current file or directory.
-		//
-		// Returns:
-		//     System.IO.FileAttributes of the current System.IO.FileSystemInfo.
-		//
-		// Exceptions:
-		//   System.IO.FileNotFoundException:
-		//     The specified file does not exist.
-		//
-		//   System.IO.DirectoryNotFoundException:
-		//     The specified path is invalid; for example, it is on an unmapped drive.
-		//
-		//   System.Security.SecurityException:
-		//     The caller does not have the required permission.
-		//
-		//   System.ArgumentException:
-		//     The caller attempts to set an invalid file attribute. -or-The user attempts
-		//     to set an attribute value but does not have write permission.
-		//
-		//   System.IO.IOException:
-		//     System.IO.FileSystemInfo.Refresh() cannot initialize the data.
-		public FileAttributes Attributes
+	    public abstract System.IO.FileSystemInfo SystemInfo { get; }
+
+        // Summary:
+        //     Gets or sets the attributes for the current file or directory.
+        //
+        // Returns:
+        //     System.IO.FileAttributes of the current System.IO.FileSystemInfo.
+        //
+        // Exceptions:
+        //   System.IO.FileNotFoundException:
+        //     The specified file does not exist.
+        //
+        //   System.IO.DirectoryNotFoundException:
+        //     The specified path is invalid; for example, it is on an unmapped drive.
+        //
+        //   System.Security.SecurityException:
+        //     The caller does not have the required permission.
+        //
+        //   System.ArgumentException:
+        //     The caller attempts to set an invalid file attribute. -or-The user attempts
+        //     to set an attribute value but does not have write permission.
+        //
+        //   System.IO.IOException:
+        //     System.IO.FileSystemInfo.Refresh() cannot initialize the data.
+        public FileAttributes Attributes
 		{
 			get
 			{
+			    if (Common.IsRunningOnMono()) return SystemInfo.Attributes;
+
 				return Common.GetAttributes(FullPath);
 			}
 			set
 			{
-				Common.SetAttributes(FullPath, value);
+			    if (Common.IsRunningOnMono())
+			        SystemInfo.Attributes = value;
+			    else
+			        Common.SetAttributes(FullPath, value);
 			}
 		}
 
@@ -74,12 +81,16 @@ namespace Pri.LongPath
 		{
 			get
 			{
-				return CreationTimeUtc.ToLocalTime();
+			    if(Common.IsRunningOnMono()) return SystemInfo.CreationTime;
+                return CreationTimeUtc.ToLocalTime();
 			}
 
 			set
 			{
-				CreationTimeUtc = value.ToUniversalTime();
+			    if (Common.IsRunningOnMono())
+			        SystemInfo.CreationTime = value;
+			    else
+			        CreationTimeUtc = value.ToUniversalTime();
 			}
 		}
 
@@ -108,7 +119,9 @@ namespace Pri.LongPath
 		{
 			get
 			{
-				if (state == State.Uninitialized)
+			    if (Common.IsRunningOnMono()) return SystemInfo.CreationTimeUtc;
+
+                if (state == State.Uninitialized)
 				{
 					Refresh();
 				}
@@ -120,7 +133,13 @@ namespace Pri.LongPath
 			}
 			set
 			{
-				if (this is DirectoryInfo)
+			    if (Common.IsRunningOnMono())
+			    {
+			        SystemInfo.CreationTimeUtc = value;
+			        return;
+			    }
+
+                if (this is DirectoryInfo)
 					Directory.SetCreationTimeUtc(FullPath, value);
 				else
 					File.SetCreationTimeUtc(FullPath, value);
@@ -132,11 +151,14 @@ namespace Pri.LongPath
 		{
 			get
 			{
-				return LastWriteTimeUtc.ToLocalTime();
+			    if (Common.IsRunningOnMono()) return SystemInfo.LastWriteTime;
+
+                return LastWriteTimeUtc.ToLocalTime();
 			}
 			set
 			{
-				LastWriteTimeUtc = value.ToUniversalTime();
+			    if (Common.IsRunningOnMono()) SystemInfo.LastWriteTime = value;
+                else LastWriteTimeUtc = value.ToUniversalTime();
 			}
 		}
 
@@ -196,7 +218,10 @@ namespace Pri.LongPath
 		{
 			get
 			{
-				if (state == State.Uninitialized)
+			    if (Common.IsRunningOnMono()) return SystemInfo.LastWriteTimeUtc;
+
+
+                if (state == State.Uninitialized)
 				{
 					Refresh();
 				}
@@ -208,7 +233,14 @@ namespace Pri.LongPath
 			}
 			set
 			{
-				if (this is DirectoryInfo)
+			    if (Common.IsRunningOnMono())
+			    {
+			        SystemInfo.LastWriteTimeUtc = value;
+			        return;
+			    }
+
+
+                if (this is DirectoryInfo)
 					Directory.SetLastWriteTimeUtc(FullPath, value);
 				else
 					File.SetLastWriteTimeUtc(FullPath, value);
@@ -220,11 +252,14 @@ namespace Pri.LongPath
 		{
 			get
 			{
-				return LastAccessTimeUtc.ToLocalTime();
+			    if (Common.IsRunningOnMono()) return SystemInfo.LastAccessTime;
+
+                return LastAccessTimeUtc.ToLocalTime();
 			}
 			set
 			{
-				LastAccessTimeUtc = value.ToUniversalTime();
+			    if (Common.IsRunningOnMono()) SystemInfo.LastAccessTime = value;
+			    else LastAccessTimeUtc = value.ToUniversalTime();
 			}
 		}
 
@@ -232,7 +267,9 @@ namespace Pri.LongPath
 		{
 			get
 			{
-				if (state == State.Uninitialized)
+			    if (Common.IsRunningOnMono()) return SystemInfo.LastAccessTimeUtc;
+
+                if (state == State.Uninitialized)
 				{
 					Refresh();
 				}
@@ -244,7 +281,14 @@ namespace Pri.LongPath
 			}
 			set
 			{
-				if (this is DirectoryInfo)
+			    if (Common.IsRunningOnMono())
+			    {
+			        SystemInfo.LastAccessTimeUtc = value;
+			        return;
+			    }
+
+
+                if (this is DirectoryInfo)
 					Directory.SetLastAccessTimeUtc(FullPath, value);
 				else
 					File.SetLastAccessTimeUtc(FullPath, value);

--- a/Pri.LongPath/JunctionPoint.cs
+++ b/Pri.LongPath/JunctionPoint.cs
@@ -27,7 +27,6 @@ namespace Pri.LongPath {
     /// </summary>
     public static class JunctionPoint
     {
-
 		/// <summary>
         /// Creates a junction point from the specified directory to the specified target directory.
         /// </summary>

--- a/Pri.LongPath/Path.cs
+++ b/Pri.LongPath/Path.cs
@@ -22,7 +22,10 @@ namespace Pri.LongPath
 
 		internal static string NormalizeLongPath(string path)
 		{
-			return NormalizeLongPath(path, "path");
+		    if (Common.IsRunningOnMono())
+		        return path;
+
+            return NormalizeLongPath(path, "path");
 		}
 
 		// Normalizes path (can be longer than MAX_PATH) and adds \\?\ long path prefix
@@ -217,6 +220,8 @@ namespace Pri.LongPath
 
 		public static string GetDirectoryName(string path)
 		{
+		    if (Common.IsRunningOnMono()) return System.IO.Path.GetDirectoryName(path);
+
 			if (path == null) throw new ArgumentNullException("path");
 			Path.CheckInvalidPathChars(path);
 		    string basePath = null;


### PR DESCRIPTION
This PR adds support for using LongPath in a cross-platform, or mono style application, as with the native calls, they do not exist on the linux based OSes, I have just defaulted this to use System.IO, wrapping it in the types of LongPath.

Notes:
`DirectoryInfo.GetFileSystemInfos(string, SearchOption)` is hackily implemented on .net 2.0 as this is not actually a supported .net 2 function. [see here](https://msdn.microsoft.com/en-us/library/dd383457(v=vs.110).aspx)
Within the PR, the tab spacing is inconsistent, namely because, from looking at the current code base, it has been almost impossible to determine the wanted code style.