### PR TITLE
Don't throw on Delete for missing file

### DIFF
--- a/Pri.LongPath/File.cs
+++ b/Pri.LongPath/File.cs
@@ -220,17 +220,23 @@ namespace Pri.LongPath
 		/// </exception>
 		public static void Delete(string path)
 		{
-		    if (Common.IsRunningOnMono() && Common.IsPlatformUnix())
-		    {
-		        SysFile.Delete(path);
-		        return;
-		    }
+			const int fileNotFoundWindowsErrorCode = 2;
 
-            string normalizedPath = Path.NormalizeLongPath(path);
-			if (!NativeMethods.DeleteFile(normalizedPath))
+			if (Common.IsRunningOnMono() && Common.IsPlatformUnix())
 			{
-				throw Common.GetExceptionFromLastWin32Error();
+				SysFile.Delete(path);
+				return;
 			}
+
+			string normalizedPath = Path.NormalizeLongPath(path);
+
+			if (NativeMethods.DeleteFile(normalizedPath))
+				return;
+
+			if (fileNotFoundWindowsErrorCode == Marshal.GetLastWin32Error())
+				return;
+
+			throw Common.GetExceptionFromLastWin32Error();
 		}
 
 		public static void Decrypt(string path)

--- a/Tests/FileTests.cs
+++ b/Tests/FileTests.cs
@@ -1343,6 +1343,12 @@ namespace Tests
 			var dt = File.GetLastWriteTime("gibberish");
 		}
 
+		[Test]
+		public void TestDeleteOnMissingFileDoesNotThrow()
+		{
+			File.Delete("missing.file");
+		}
+
 		[TearDown]
 		public void TearDown()
 		{


### PR DESCRIPTION
This way we match behavior of System.IO.File.Delete and avoid unexpected
errors

This fixes issue #70 