### PR TITLE
Directory.Move falling back to File.Move

### DIFF
--- a/Pri.LongPath/Directory.cs
+++ b/Pri.LongPath/Directory.cs
@@ -723,7 +723,7 @@ namespace Pri.LongPath
 		{
 		    if (Common.IsRunningOnMono() && Common.IsPlatformUnix())
 			{
-				System.IO.File.Move(sourcePath, destinationPath);
+				System.IO.Directory.Move(sourcePath, destinationPath);
 		        return;
 		    }
 


### PR DESCRIPTION
Found out that Directory.Move falls back to System.IO.File.Move instead of System.IO.Directory.Move when running on Mono -which results in a FileNotFoundException.